### PR TITLE
Fix github url errors introduced by rename

### DIFF
--- a/OpenData.ctv
+++ b/OpenData.ctv
@@ -9,7 +9,7 @@
 
 Another key issue in a data-focused TaskView is the meaning of "open" data. This TaskView covers many types of data that come with varying degrees of usage restrictions from public domain (or CC-0) data that is useable for any purpose to "freely available" data that is available at no cost but may have licenses that are not strictly speaking "open". Users should investigate the terms of use and licensing of any data referenced here before using it for any particular application.
 
-If you have any comments or suggestions for additions or improvements for this taskview, go to GitHub and <a href="https://github.com/ropensci/opendata_content/issues">submit an issue</a>, or make some changes and <a href="https://github.com/ropensci/opendata_content/pulls">submit a pull request</a>. If you can't contribute on GitHub, <a href="mailto:scott@ropensci.org">send Scott an email</a>. If you have an issue with one of the packages discussed below, please contact the maintainer of that package.
+If you have any comments or suggestions for additions or improvements for this taskview, go to GitHub and <a href="https://github.com/ropensci/opendata/issues">submit an issue</a>, or make some changes and <a href="https://github.com/ropensci/opendata/pulls">submit a pull request</a>. If you can't contribute on GitHub, <a href="mailto:scott@ropensci.org">send Scott an email</a>. If you have an issue with one of the packages discussed below, please contact the maintainer of that package.
 
 If you know of a web service, API, data source, or other online resource that is not yet supported by an R package, consider adding it to <a href="https://github.com/ropensci/opendata/wiki/ToDo">the package development to do list on GitHub</a>.
 

--- a/README.md
+++ b/README.md
@@ -23,16 +23,15 @@ speaking "open". Users should investigate the terms of use and licensing
 of any data referenced here before using it for any particular
 application. If you have any comments or suggestions for additions or
 improvements for this taskview, go to GitHub and [submit an
-issue](https://github.com/ropensci/opendata_content/issues), or make
-some changes and [submit a pull
-request](https://github.com/ropensci/opendata_content/pulls). If you
-can't contribute on GitHub, [send Scott an
-email](mailto:scott@ropensci.org). If you have an issue with one of the
-packages discussed below, please contact the maintainer of that package.
-If you know of a web service, API, data source, or other online resource
-that is not yet supported by an R package, consider adding it to [the
-package development to do list on
-GitHub](https://github.com/ropensci/opendata/wiki/ToDo).
+issue](https://github.com/ropensci/opendata/issues), or make some
+changes and [submit a pull
+request](https://github.com/ropensci/opendata/pulls). If you can't
+contribute on GitHub, [send Scott an email](mailto:scott@ropensci.org).
+If you have an issue with one of the packages discussed below, please
+contact the maintainer of that package. If you know of a web service,
+API, data source, or other online resource that is not yet supported by
+an R package, consider adding it to [the package development to do list
+on GitHub](https://github.com/ropensci/opendata/wiki/ToDo).
 
 Data Discovery and Data Archiving
 ---------------------------------

--- a/opendata_content.ctv
+++ b/opendata_content.ctv
@@ -9,7 +9,7 @@
 
 Another key issue in a data-focused TaskView is the meaning of "open" data. This TaskView covers many types of data that come with varying degrees of usage restrictions from public domain (or CC-0) data that is useable for any purpose to "freely available" data that is available at no cost but may have licenses that are not strictly speaking "open". Users should investigate the terms of use and licensing of any data referenced here before using it for any particular application.
 
-If you have any comments or suggestions for additions or improvements for this taskview, go to GitHub and <a href="https://github.com/ropensci/opendata_content/issues">submit an issue</a>, or make some changes and <a href="https://github.com/ropensci/opendata_content/pulls">submit a pull request</a>. If you can't contribute on GitHub, <a href="mailto:scott@ropensci.org">send Scott an email</a>. If you have an issue with one of the packages discussed below, please contact the maintainer of that package.
+If you have any comments or suggestions for additions or improvements for this taskview, go to GitHub and <a href="https://github.com/ropensci/opendata/issues">submit an issue</a>, or make some changes and <a href="https://github.com/ropensci/opendata/pulls">submit a pull request</a>. If you can't contribute on GitHub, <a href="mailto:scott@ropensci.org">send Scott an email</a>. If you have an issue with one of the packages discussed below, please contact the maintainer of that package.
 
 If you know of a web service, API, data source, or other online resource that is not yet supported by an R package, consider adding it to <a href="https://github.com/ropensci/opendata/wiki/ToDo">the package development to do list on GitHub</a>.
 


### PR DESCRIPTION
Fixes errors in github URLs in last PR. (Many referred to `ropensci/opendata_content`)
