### PR TITLE
Makefile change suggested in #68

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,10 @@ ctv2html:
 
 readme:
 	pandoc -w markdown_github -o README.md OpenData.html
-	sed -i -e 's|( \[|(\[|g' README.md
-	sed -i '' 's|../packages/|http://cran.rstudio.com/web/packages/|g' README.md
-	sed -i '' 's/^[|]-/*Do not edit this README by hand. See \[CONTRIBUTING.md\]\(CONTRIBUTING.md\).*\n\n|||\n|-/g' README.md
+	sed -i.tmp 's|( \[|(\[|g' README.md
+	sed -i.tmp 's|../packages/|http://cran.rstudio.com/web/packages/|g' README.md
+	sed -i.tmp 's/^[|]-/*Do not edit this README by hand. See \[CONTRIBUTING.md\]\(CONTRIBUTING.md\).*\n\n|||\n|-/g' README.md
+	rm *.tmp
 
 md2html:
 	pandoc -o README.html README.md


### PR DESCRIPTION
Per @leeper: issue may be the one
[described here](http://stackoverflow.com/questions/4247068/sed-command-failing-on-mac-but-works-on-linux)
with the use of the `sed` with an `-i` argument. I'm using GNU sed 4.2.2 and it
apparently wants just `sed -i 'expression' FILE`, whereas I'm thinking you're
using the default sed on Mac (from BSD), which wants `sed -i 'extension'
'expression' FILE`.

[the easiest solution](http://unix.stackexchange.com/questions/92895/how-to-achieve-portability-with-sed-i-in-place-editing)
is to change the Makefile
