### PR TITLE
Clean up package lead, remove data sharing packages

### DIFF
--- a/OpenData.ctv
+++ b/OpenData.ctv
@@ -2,56 +2,32 @@
   <name>OpenData</name>
   <topic>Open Data</topic>
   <maintainer email="jashander@ucdavis.edu">Jaime Ashander, Scott Chamberlain, Thomas Leeper</maintainer>
-  <version>2017-02-16</version>
+  <version>2017-02-17</version>
   <info>
-    <p>This Task View contains information about using R to obtain, parse, manipulate, create, and share open data. Much open data is available on the web, and the <a href="http://cran.r-project.org/web/views/WebTechnologies.html">WebTechnologies</a> TaskView addresses how to obtain and parse web-based data. There is obvious overlap between the two TaskViews, so some packages are described on both. There is also a considerable amount of open data available as R packages on CRAN. We point readers to the <pkg>crandatapkgs</pkg> package to obtain information about currently available open data in R packages.</p>
+    <p>This Task View contains information about using R to obtain open data. Much open data is available on the web, and the <a href="http://cran.r-project.org/web/views/WebTechnologies.html">WebTechnologies</a> TaskView generally addresses how to obtain and parse web-based data. There is obvious overlap between the two TaskViews, so some packages are described on both. There is also a considerable amount of open data available as R packages on CRAN. We point readers to the <pkg>crandatapkgs</pkg> package to obtain information about currently available open data in R packages.</p>
     <p>Another key issue in a data-focused TaskView is the meaning of &quot;open&quot; data. This TaskView covers many types of data that come with varying degrees of usage restrictions from public domain (or CC-0) data that is usable for any purpose to &quot;freely available&quot; data that is available at no cost but may have licenses that are not strictly speaking &quot;open&quot;. Users should investigate the terms of use and licensing of any data referenced here before using it for any particular application. Additionally, the view lists wrappers for paid APIs, as well as those that require an account but are not necessarily subscription only. These are marked ($) and (K) respectively.</p>
     <p>If you have any comments or suggestions for additions, revisions, or improvements for this taskview, go to GitHub and <a href="https://github.com/ropensci/opendata/issues">submit an issue</a>, or make some changes and <a href="https://github.com/ropensci/opendata/pulls">submit a pull request</a>. If you can't contribute on GitHub, <a href="mailto:jashander@ucdavis.edu?subject=Open%20Data%20Task%20View">send Jaime an email</a>. If you have an issue with one of the packages discussed below, please contact the maintainer of that package.</p>
     <p>If you know of a web service, API, data source, or other online resource that is not yet supported by an R package, consider adding it to <a href="https://github.com/ropensci/opendata/wiki/ToDo">the package development to do list on GitHub</a>.</p>
-    <h2 id="data-sharing-and-archiving">Data Sharing and Archiving</h2>
-    <p>Data sharing involves the dissemination of data in draft form or for a temporary period of time. rdrop2 (<a href="https://github.com/karthik/rdrop2">GitHub</a>) is a Dropbox.com interface from R, providing access to a full suite of file operations, including dir/copy/move/delete operations, account information (including quotas) and the ability to upload and download files from any Dropbox account (K). <a href="https://github.com/brendan-R/boxr">boxr</a> is a lightweight, high-level R interface for the <a href="https://developers.box.com/docs/">box.com API</a> (K). <ohat>RAmazonS3</ohat> provides an interface to the Amazon Simple Storage Service (S3) (K).</p>
-    <p>Data archiving involves the production and dissemination of open data that is persistently accessible, typically in public repositories. The tools below may be useful for both archiving data and retrieving extant data from public archives.</p>
-    <ul>
-    <li><a href="https://github.com/ropensci/ckanr">ckanr</a>: A generic R client to interact with the CKAN data portal software API (<a href="http://ckan.org/" class="uri">http://ckan.org/</a>). Allows user to swap out the base URL to use any CKAN instance. <a href="https://github.com/ropensci/ckanr">Source on GitHub</a>.</li>
-    <li><a href="https://cran.rstudio.com/src/contrib/Archive/dataone/">dataone</a>: Read/write access to data and metadata from the <a href="https://www.dataone.org/">DataONE network</a> of Member Node data repositories.</li>
-    <li><pkg>dvn</pkg> (<a href="https://github.com/ropensci/dvn">GitHub</a>) provides access to Dataverse Network repositories. <pkg>UNF</pkg> implements the Universal Numeric Fingerprint, a format-independent data hashing algorithm used by Dataverse, to verify and cite a dataset.</li>
-    <li><pkg>factualR</pkg>: Thin wrapper for the <a href="https://factual.com/">Factual.com</a> server API.</li>
-    <li>The <ohat>Rflickr</ohat> (not on CRAN) package provides an R interface to the Flickr photo management and sharing application Web service. (not on CRAN) (K)</li>
-    <li><a href="https://github.com/jennybc/googlesheets">googlesheets</a> (not on CRAN): Access private or public Google Sheets by title, key, or URL. Extract data or edit data. Create, delete, rename, copy, upload, or download spreadsheets and worksheets. <a href="https://github.com/jennybc/googlesheets">Source on GitHub</a></li>
-    <li><pkg>gsheet</pkg>: Download Google Sheets using just the sharing link. Spreadsheets can be downloaded as a data frame, or as plain text to parse manually. <a href="https://github.com/maxconway/gsheet">Source on GitHub</a></li>
-    <li><pkg>imguR</pkg> (<a href="https://github.com/leeper/imguR">GitHub</a>): A package to share plots using the image hosting service <a href="https://www.imgur.com/">Imgur.com</a>. knitr also has a function <code>imgur_upload()</code> to load images from literate programming documents.</li>
-    <li><a href="https://cran.rstudio.com/src/contrib/Archive/infochimps/">infochimps</a> (archived on CRAN; <a href="https://github.com/drewconway/infochimps">GitHub</a>) is an R wrapper for the infochimps.com API services, from <a href="http://drewconway.com/">Drew Conway</a>.</li>
-    <li><a href="https://github.com/ropensci/internetarchive">internetarchive</a> (not on CRAN): API client for internet archive metadata. <a href="https://github.com/ropensci/internetarchive">Source on GitHub</a>.</li>
-    <li><pkg>jSonarR</pkg>: Enables users to access MongoDB by running queries and returning their results in R data frames. jSonarR uses data processing and conversion capabilities in the jSonar Analytics Platform and the <a href="http://www.jsonstudio.com">JSON Studio Gateway</a>, to convert JSON to a tabular format.</li>
-    <li><pkg>OAIHarvester</pkg>: Harvest metadata using the Open Archives Initiative Protocol for Metadata Harvesting (OAI-PMH). <pkg>oai</pkg> is a more recent package for OAI.</li>
-    <li><pkg>Quandl</pkg>: A package that interacts directly with the <a href="https://www.quandl.com/">Quandl</a> API to offer data in a number of formats usable in R, as well as the ability to upload and search.</li>
-    <li><pkg>rdatamarket</pkg>: Fetches data from DataMarket.com, either as timeseries in zoo form (dmseries) or as long-form data frames (dmlist).</li>
-    <li><a href="https://github.com/ropensci/rerddap">rerddap</a> (not on CRAN): A generic R client to interact with any ERDDAP instance, which is a special case of OPeNDAP (<a href="https://en.wikipedia.org/wiki/OPeNDAP" class="uri">https://en.wikipedia.org/wiki/OPeNDAP</a>), or <em>Open-source Project for a Network Data Access Protocol</em>. Allows user to swap out the base URL to use any ERDDAP instance. <a href="https://github.com/ropensci/rerddap">Source on GitHub</a>.</li>
-    <li><pkg>rfigshare</pkg>: Programmatic interface for <a href="https://figshare.com/">Figshare.com</a>. <a href="https://github.com/ropensci/rfigshare">Source on GitHub</a>.</li>
-    <li><a href="https://github.com/leeper/rscribd">rscribd</a> (not on CRAN): API client for publishing documents to <a href="https://www.scribd.com/">Scribd</a>.</li>
-    <li><a href="https://cran.rstudio.com/src/contrib/Archive/RSocrata/">RSocrata</a>: (temporarily archived on CRAN for email bounce) Provided with a Socrata dataset resource URL, or a Socrata SoDA web API query, returns an R data frame. Converts dates to POSIX format. Supports CSV and JSON. Manages throttling by Socrata.</li>
-    </ul>
-    <h2 id="web-based-open-data">Web-based Open Data</h2>
-    <p><a href="#agriculture">Agriculture</a> | <a href="#astronomy">Astronomy</a> | <a href="#business">Business</a> | <a href="#chemistry">Chemistry</a> | <a href="#climate">Climate</a> | <a href="#earth-science">Earth Science</a> | <a href="#ecological-and-evolutionary-biology">Ecology/Evolution</a> | <a href="#finance">Finance</a> | <a href="#genes-and-genomes">Genes/Genomes</a> | <a href="#geocoding">Geocoding</a> | <a href="#google-analytics">Google Analytics</a> | <a href="#google-web-services">Google Web Services</a> | <a href="#government">Government and Economics</a> | <a href="#literature-metadata-text-and-altmetrics">Literature/Text-mining</a> | <a href="#maps">Maps</a> | <a href="#marketing">Marketing</a> | <a href="#ncbi">NCBI</a> | <a href="#news">News</a> | <a href="#other">Other</a> | <a href="#public-health">Public Health</a> | <a href="#social-media">Social Media</a> | <a href="#social-science">Social Science</a> | <a href="#sports">Sports</a> | <a href="#web-analytics">Web Analytics</a> | <a href="#wikipedia">Wikipedia</a> |</p>
-    <h3 id="agriculture">Agriculture</h3>
+    <p><a href="#agriculture">Agriculture</a> | <a href="#astronomy">Astronomy</a> | <a href="#chemistry">Chemistry</a> | <a href="#earth-science">Earth Science</a> | <a href="#ecological-and-evolutionary-biology">Ecology/Evolution</a> | <a href="#finance">Finance</a> | <a href="#genes-and-genomes">Genes/Genomes</a> | <a href="#geocoding">Geocoding</a> | <a href="#google-analytics">Google Analytics</a> | <a href="#google-web-services">Google Web Services</a> | <a href="#government">Government and Economics</a> | <a href="#literature-metadata-text-and-altmetrics">Literature/Text-mining</a> | <a href="#maps">Maps</a> | <a href="#marketing">Marketing</a> | <a href="#ncbi">NCBI</a> | <a href="#news">News</a> | <a href="#other">Other</a> | <a href="#public-health">Public Health</a> | <a href="#social-media">Social Media</a> | <a href="#social-science">Social Science</a> | <a href="#sports">Sports</a> | <a href="#web-analytics">Web Analytics</a> | <a href="#wikipedia">Wikipedia</a> |</p>
+    <h2 id="agriculture">Agriculture</h2>
     <ul>
     <li><a href="https://cran.rstudio.com/src/contrib/Archive/cimis/">cimis</a>: R package for retrieving data from CIMIS, the California Irrigation Management Information System. Available in CRAN archives only.</li>
     <li><pkg>FAOSTAT</pkg>: The package hosts a list of functions to download, manipulate, construct and aggregate agricultural statistics provided by the FAOSTAT (Food and Agricultural Organization of the United Nations) database.</li>
     </ul>
-    <h3 id="astronomy">Astronomy</h3>
+    <h2 id="astronomy">Astronomy</h2>
     <ul>
     <li><pkg>RStars</pkg>: Star-API provides API access to the American Museum of Natural History's Digital Universe Data, including positions, luminosity, color, and other data on over 100,000 stars as well as constellations, exo-planets, clusters and others. <a href="https://github.com/ropensci/RStars">Source on GitHub</a>.</li>
     </ul>
-    <h3 id="business">Business</h3>
+    <h2 id="business">Business</h2>
     <ul>
     <li><a href="https://github.com/abresler/forbesListR">forbesListR</a> (not on CRAN) offers access to a number of business-related datasets provided by Forbes.</li>
     </ul>
-    <h3 id="chemistry">Chemistry</h3>
+    <h2 id="chemistry">Chemistry</h2>
     <ul>
     <li><pkg>rpubchem</pkg>: Interface to the PubChem Collection.</li>
     <li><pkg>webchem</pkg>: Retrieve chemical information from a suite of web APIs for chemical information. <a href="https://github.com/ropensci/webchem">Source on GitHub</a></li>
     </ul>
-    <h3 id="earth-science">Earth Science</h3>
+    <h2 id="earth-science">Earth Science</h2>
     <ul>
     <li><pkg>dataRetrieval</pkg>: Collection of functions to help retrieve USGS data from either web services or user-provided data files. <a href="https://github.com/USGS-R/dataRetrieval">on GitHub</a>.</li>
     <li><pkg>hddtools</pkg>: Hydrological data discovery tools - accesses data from NASA, Global Runoff Data Centre, Top-Down modelling Working Group. <a href="https://github.com/cvitolo/r_hddtools">Source on GitHub</a></li>
@@ -145,7 +121,7 @@
     <li><a href="https://github.com/sckott/rphylopic">rphylopic</a> (not on CRAN): An R client for <a href="http://phylopic.org/">Phylopic.org</a>, a databaes of free silhouettes of animals, embedded in a phylogenetic information framework. <a href="https://github.com/sckott/rphylopic">Source on GitHub</a></li>
     <li><pkg>treebase</pkg>: An R package for discovery, access and manipulation of online phylogenies. <a href="https://github.com/ropensci/treebase">Source on GitHub</a></li>
     </ul>
-    <h3 id="finance">Finance</h3>
+    <h2 id="finance">Finance</h2>
     <ul>
     <li><pkg>dataonderivatives</pkg> Post-GFC derivatives reforms have lifted the veil off over-the-counter (OTC) derivative markets. Swap Execution Facilities (SEFs) and Swap Data Repositories (SDRs) now publish data on swaps that are traded on or reported to those facilities (respectively). This package provides you the ability to get this data from supported sources.</li>
     <li><a href="https://github.com/CharlesCara/Datastream2R">Datastream2R</a> (not on CRAN): Another package for accessing the Datastream service. This package downloads data from the Thomson Reuters DataStream DWE server, which provides XML access to the Datastream database of economic and financial information.</li>
@@ -166,7 +142,7 @@
     <li><pkg>tseries</pkg>: Includes the <code>get.hist.quote</code> for historical financial data.</li>
     <li><pkg>ustyc</pkg>: US Treasury yield curve data retrieval. Development version on GitHub <a href="https://github.com/mrbcuda/ustyc">here</a>.</li>
     </ul>
-    <h3 id="genes-and-genomes">Genes and Genomes</h3>
+    <h2 id="genes-and-genomes">Genes and Genomes</h2>
     <ul>
     <li><a href="https://github.com/balcomes/aggRmesh">aggRmesh</a>: R client for the <a href="http://portal.ncibi.org/gateway/">National Center for Integrative Biomedical Informatics (NCIBI)</a> data.</li>
     <li><pkg>cgdsr</pkg>: R-Based API for accessing the MSKCC Cancer Genomics Data Server (CGDS).</li>
@@ -180,20 +156,20 @@
     <li><pkg>SoyNAM</pkg>: Genomic and multi-environmental soybean data. Soybean Nested Association Mapping (SoyNAM) project dataset funded by the United Soybean Board (USB), pre-formatted for general analysis and genome-wide association analysis using the NAM package.</li>
     <li>NCBI EUtils web services: See the NCBI section</li>
     </ul>
-    <h3 id="geocoding">Geocoding</h3>
+    <h2 id="geocoding">Geocoding</h2>
     <ul>
     <li><pkg>geocodeHERE</pkg>: Wrapper for Nokia's <a href="http://here.com/">HERE</a> geocoding API. API docs: <a href="https://developer.here.com/geocoder" class="uri">https://developer.here.com/geocoder</a>. <a href="https://github.com/corynissen/geocodeHERE">Source on GitHub</a></li>
     <li><a href="https://github.com/hrbrmstr/ipapi">ipapi</a>: Geolocate IPv4/6 addresses and/or domain names using the <a href="http://ip-api.com/">ip-api.com</a> API. <a href="https://github.com/hrbrmstr/ipapi">Source on GitHub</a></li>
     <li><a href="https://github.com/sckott/openadds">openadds</a> is an R client for <a href="http://openaddresses.io/">OpenAddresses</a> a free and open global address collection. <a href="https://github.com/sckott/openadds">Source on GitHub</a></li>
     </ul>
-    <h3 id="google-analytics">Google Analytics</h3>
+    <h2 id="google-analytics">Google Analytics</h2>
     <ul>
     <li><a href="https://github.com/jdeboer/ganalytics">ganalytics</a> (not on CRAN): Interface to <a href="https://developers.google.com/analytics/">Google Analytics APIs</a>. <a href="https://github.com/jdeboer/ganalytics">Source on GitHub</a></li>
     <li><pkg>GAR</pkg>: Interface to <a href="https://developers.google.com/analytics/">Google Analytics APIs</a>. <a href="https://github.com/andrewgeisler/GAR">Source on GitHub</a></li>
     <li><pkg>RGA</pkg>: Provides functions for accessing and retrieving data from the <a href="https://developers.google.com/analytics/">Google Analytics APIs</a>. Supports OAuth 2.0 authorization. Also, the RGA package provides a shiny app to explore data. There is another R package for the same service (RGoogleAnalytics); see above entry.</li>
     <li><pkg>RGoogleAnalytics</pkg>: Provides functions for accessing and retrieving data from the Google Analytics API. <a href="https://github.com/Tatvic/RGoogleAnalytics/issues">Source on GitHub</a>. There is another R package for the same service (RGA); see next entry.</li>
     </ul>
-    <h3 id="google-web-services">Google Web Services</h3>
+    <h2 id="google-web-services">Google Web Services</h2>
     <ul>
     <li><pkg>bigrquery</pkg>: An interface to Google's bigquery from R. <a href="https://github.com/hadley/bigrquery">Source on GitHub</a> (K)</li>
     <li><a href="https://github.com/jdeboer/ganalytics">ganalytics</a> (not on CRAN): Interface to <a href="https://developers.google.com/analytics/">Google Analytics APIs</a>. <a href="https://github.com/jdeboer/ganalytics">Source on GitHub</a> (K)</li>
@@ -213,7 +189,7 @@
     <li><pkg>translate</pkg>: Bindings for the Google Translate API v2</li>
     <li><pkg>translateR</pkg> provides bindings for both Google and Microsoft translation APIs.</li>
     </ul>
-    <h3 id="government">Government</h3>
+    <h2 id="government">Government</h2>
     <p>There are a very large number of packages providing access to government data. Here is a list of these packages, arranged by country and/or other jurisdiction.</p>
     <ul>
     <li><em>Australia</em>: <pkg>eechidna</pkg> provides data from the 2013 Australian Federal Election (House of Representatives) and the 2011 Australian Census.</li>
@@ -272,7 +248,7 @@
     <li>World Bank: <pkg>wbstats</pkg> can extract data from the <a href="http://data.worldbank.org/developers/api-overview">World Bank Data API</a> and the <a href="http://data.worldbank.org/developers/data-catalog-api">World Bank Data Catalog API</a>. <pkg>WDI</pkg> can search, extract and format data from the World Bank's World Development Indicators.</li>
     </ul></li>
     </ul>
-    <h3 id="literature-metadata-text-and-altmetrics">Literature, Metadata, Text, and Altmetrics</h3>
+    <h2 id="literature-metadata-text-and-altmetrics">Literature, Metadata, Text, and Altmetrics</h2>
     <ul>
     <li><pkg>alm</pkg>: R wrapper to the almetrics API platform developed by PLoS.</li>
     <li><pkg>aRxiv</pkg> (<a href="https://github.com/ropensci/aRxiv">GitHub</a>): An R client for the arXiv API, a repository of electronic preprints for computer science, mathematics, physics, quantitative biology, quantitative finance, and statistics.</li>
@@ -297,7 +273,7 @@
     <li><pkg>tm.plugin.webmining</pkg>: Extensible text retrieval framework for news feeds in XML (RSS, ATOM) and JSON formats. Currently, the following feeds are implemented: Google Blog Search, Google Finance, Google News, NYTimes Article Search, Reuters News Feed, Yahoo Finance and Yahoo Inplay.</li>
     <li><pkg>biorxivr</pkg>: interface with bioRxiv preprint server</li>
     </ul>
-    <h3 id="maps">Maps</h3>
+    <h2 id="maps">Maps</h2>
     <ul>
     <li><pkg>FedData</pkg> can download geospatial data from a number of U.S. and international data sources.</li>
     <li><pkg>ggmap</pkg>: Allows for the easy visualization of spatial data and models on top of Google Maps, OpenStreetMaps, Stamen Maps, or CloudMade Maps using ggplot2.</li>
@@ -314,7 +290,7 @@
     <li><a href="https://github.com/walkerke/tigris">tigris</a> (not on CRAN) can read US Census Bureau TIGRIS shapefiles.</li>
     <li><pkg>USAboundaries</pkg> spatial objects with the boundaries of states or counties in the United States of America from 1629 to 2000 (from the Atlas of Historical County Boundaries).</li>
     </ul>
-    <h3 id="ncbi">NCBI</h3>
+    <h2 id="ncbi">NCBI</h2>
     <ul>
     <li><pkg>hoardeR</pkg>: Information retrieval from NCBI databases, with main focus on Blast.</li>
     <li><a href="http://cran.rstudio.com/src/contrib/Archive/NCBI2R/">NCBI2R</a>: Annotates lists of SNPs and/or genes, with current information from NCBI. The CRAN version is archived.</li>
@@ -322,13 +298,13 @@
     <li><pkg>reutils</pkg> (<a href="https://github.com/gschofl/reutils">GitHub</a>): Interface with NCBI databases such as PubMed, Genbank, or GEO via the Entrez Programming Utilities (EUtils).</li>
     <li><pkg>RISmed</pkg>: Download content from NCBI databases. Intended for analyses of NCBI database content, not reference management. See rpubmed for more literature oriented stuff from NCBI.</li>
     </ul>
-    <h3 id="news">News</h3>
+    <h2 id="news">News</h2>
     <ul>
     <li><pkg>GuardianR</pkg>: Provides an interface to the Open Platform's Content API of the Guardian Media Group. It retrieves content from news outlets The Observer, The Guardian, and guardian.co.uk from 1999 to current day. <pkg>rdian</pkg> (<a href="https://github.com/ironholds/rdian">GitHub</a>) is another Guardian API client.</li>
     <li><a href="https://github.com/ropengov/rtimes">rtimes</a> (not on CRAN): R client for the New York Times APIs, including the Congress, Article Search, Campaign Finance, and Geographic APIs.</li>
     <li><em>ZEIT</em>: <pkg>diezeit</pkg> waps the ZEIT online content API (K).</li>
     </ul>
-    <h3 id="other">Other</h3>
+    <h2 id="other">Other</h2>
     <ul>
     <li><pkg>datamart</pkg>: Provides an S4 infrastructure for unified handling of internal datasets and web based data sources. Examples include dbpedia, eurostat and sourceforge.</li>
     <li><pkg>genderizeR</pkg>: Uses the genderize.io API to predict gender from first names extracted from a text vector. <a href="https://github.com/kalimu/genderizeR">Source on GitHub</a></li>
@@ -344,7 +320,7 @@
     <li><pkg>TMDb</pkg> can retrieve data from <a href="https://www.themoviedb.org">The Movie Database</a>.</li>
     <li><pkg>zendeskR</pkg>: This package provides an R wrapper for the Zendesk API. ($)</li>
     </ul>
-    <h3 id="public-health">Public Health</h3>
+    <h2 id="public-health">Public Health</h2>
     <ul>
     <li><a href="https://github.com/hrbrmstr/cdcfluview">cdcfluview</a>: (not on CRAN) R client for CDC FluView data (WHO and ILINet).</li>
     <li><pkg>nhanesA</pkg> Utility to retrieve data from the National Health and Nutrition Examination Survey (NHANES).</li>
@@ -355,7 +331,7 @@
     <li><a href="https://gitlab.com/iembry/vaers">vaers</a> (not on CRAN) provides U.S. vaccine adverse event data from the <a href="https://vaers.hhs.gov/index">VAERS</a> vaccine surveillance program. <pkg>vaersvax</pkg> provides a subset a subset of these data for three months of 2016. <pkg>vaersNDvax</pkg> provides non-domestic data for the same period.</li>
     <li>WHO: <pkg>WHO</pkg> (<a href="https://www.github.com/expersso/WHO">GitHub</a>) provides an interface to the <a href="http://www.who.int/">World Health Organization</a> API. <pkg>rgho</pkg> (<a href="https://github.com/pierucci/rgho">GitHub</a>) connects to the WHO Global Health Observatory data.</li>
     </ul>
-    <h3 id="social-media">Social media</h3>
+    <h2 id="social-media">Social media</h2>
     <ul>
     <li><em>Facebook</em>: <pkg>Rfacebook</pkg> provides an interface to the Facebook API. (K)</li>
     <li><em>Google+</em>: <pkg>plusser</pkg> has been designed to to facilitate the retrieval of Google+ profiles, pages and posts. It also provides search facilities. Currently a Google+ API key is required for accessing Google+ data. <a href="https://github.com/soodoku/tuber">tuber</a> provides bindings for YouTube API. Only on Github for now. (K)</li>
@@ -366,7 +342,7 @@
     <li><pkg>SocialMediaLab</pkg> provides a convenient wrapper around many other social media clients and enables the construction of network structures from those data.</li>
     <li><pkg>SocialMediaMineR</pkg> is an analytic tool that returns information about the popularity of a URL on social media sites.</li>
     </ul>
-    <h3 id="social-science">Social science</h3>
+    <h2 id="social-science">Social science</h2>
     <ul>
     <li><a href="http://www.asdfree.com/">asdfree: analyze survey data for free</a> (not a package) provides lots of code examples for analyzing survey data in R. Also on <a href="https://github.com/ajdamico/usgsd">github</a>.</li>
     <li><pkg>brewdata</pkg> Retrieves and parses graduate admissions survey data from the <a href="http://thegradcafe.com">Grad Cafe website</a>.</li>
@@ -380,7 +356,7 @@
     <li><pkg>wordbankr</pkg> (<a href="https://github.com/langcog/wordbankr">GitHub</a>) connects to <a href="http://wordbank.stanford.edu/">Wordbank</a>, a database of childrens' developmental vocabulary.</li>
     <li>The <ohat>Zillow</ohat> (not on CRAN) package provides an R interface to the <a href="http://www.zillow.com/">Zillow</a> Web Service API. It allows one to get the Zillow estimate for the price of a particular property specified by street address and ZIP code (or city and state), to find information (e.g. size of property and lot, number of bedrooms and bathrooms, year built.) about a given property, and to get comparable properties.</li>
     </ul>
-    <h3 id="sports">Sports</h3>
+    <h2 id="sports">Sports</h2>
     <ul>
     <li><a href="https://github.com/phillc73/abettor">abettor</a> (not on CRAN): Online betting exchange, Betfair, API wrapper in R. (K)</li>
     <li><a href="https://github.com/rtelmore/ballr">ballr</a> (not on CRAN) is a client for <a href="http://www.basketball-reference.com/">Basketball-Reference.com</a>.</li>
@@ -396,7 +372,7 @@
     <li><pkg>retrosheet</pkg> (<a href="https://github.com/rmscriven/retrosheet">Github</a>) retrieves single-season baseball statistics from <a href="http://www.retrosheet.org" class="uri">http://www.retrosheet.org</a>.</li>
     <li><pkg>yorkr</pkg> provides access to cricket data from <a href="http://cricsheet.org">Cricsheet</a>.</li>
     </ul>
-    <h3 id="web-analytics">Web Analytics</h3>
+    <h2 id="web-analytics">Web Analytics</h2>
     <ul>
     <li><a href="https://github.com/dvanclev/GTrendsR">GTrendsR</a> (not on CRAN): R functions to perform and display Google Trends queries. Another Github package (<a href="https://github.com/emhart/rGtrends">rGtrends</a>) is now deprecated, but supported a previous version of Google Trends and may still be useful for developers.</li>
     <li>rgauges (<a href="https://cran.r-project.org/src/contrib/Archive/rgauges">Archived on CRAN</a>) This package provides functions to interact with the Gaug.es API. Gaug.es is a web analytics service, like Google analytics. You have to have a Gaug.es account to use this package. ($) (K)</li>
@@ -405,7 +381,7 @@
     <li><ohat>RGoogleTrends</ohat> (not on CRAN) provides programmatic access to Google Trends data. This is information about the popularity of a particular query.</li>
     <li><pkg>RSiteCatalyst</pkg>: Functions for accessing the Adobe Analytics (Omniture SiteCatalyst) Reporting API.</li>
     </ul>
-    <h3 id="wikipediawikimedia">Wikipedia/Wikimedia</h3>
+    <h2 id="wikipediawikimedia">Wikipedia/Wikimedia</h2>
     <ul>
     <li><a href="https://github.com/petermeissner/wikipediatrend">wikipediatrend</a> (removed from CRAN): Provides access to Wikipedia page access statistics.</li>
     <li><pkg>WikipediR</pkg>: WikipediR is a wrapper for the MediaWiki API, aimed particularly at the Wikimedia 'production' wikis, such as Wikipedia. <a href="https://github.com/Ironholds/WikipediR">Source on GitHub</a></li>
@@ -444,7 +420,6 @@
     <pkg>dataRetrieval</pkg>
     <pkg>diezeit</pkg>
     <pkg>dismo</pkg>
-    <pkg>dvn</pkg>
     <pkg>easyPubMed</pkg>
     <pkg>ecb</pkg>
     <pkg>ecoengine</pkg>
@@ -458,7 +433,6 @@
     <pkg>epidata</pkg>
     <pkg>estatapi</pkg>
     <pkg>eurostat</pkg>
-    <pkg>factualR</pkg>
     <pkg>FAOSTAT</pkg>
     <pkg>fbRanks</pkg>
     <pkg>FedData</pkg>
@@ -475,7 +449,6 @@
     <pkg>ggmap</pkg>
     <pkg>googleVis</pkg>
     <pkg>govStatJPN</pkg>
-    <pkg>gsheet</pkg>
     <pkg>GSODR</pkg>
     <pkg>GuardianR</pkg>
     <pkg>gutenbergr</pkg>
@@ -488,9 +461,7 @@
     <pkg>icpsrdata</pkg>
     <pkg>idbr</pkg>
     <pkg>imfr</pkg>
-    <pkg>imguR</pkg>
     <pkg>inegiR</pkg>
-    <pkg>jSonarR</pkg>
     <pkg>kokudosuuchi</pkg>
     <pkg>leafletR</pkg>
     <pkg>lumendb</pkg>
@@ -505,8 +476,6 @@
     <pkg>neotoma</pkg>
     <pkg>nhanesA</pkg>
     <pkg>nhlscrapr</pkg>
-    <pkg>oai</pkg>
-    <pkg>OAIHarvester</pkg>
     <pkg>OECD</pkg>
     <pkg>okmesonet</pkg>
     <pkg>olctools</pkg>
@@ -533,7 +502,6 @@
     <pkg>pubmed.mineR</pkg>
     <pkg>pvsR</pkg>
     <pkg>pxweb</pkg>
-    <pkg>Quandl</pkg>
     <pkg>quantmod</pkg>
     <pkg>RAdwords</pkg>
     <pkg>raincpc</pkg>
@@ -549,7 +517,6 @@
     <pkg>rclinicaltrials</pkg>
     <pkg>Rcolombos</pkg>
     <pkg>RCryptsy</pkg>
-    <pkg>rdatamarket</pkg>
     <pkg>rdefra</pkg>
     <pkg>rdian</pkg>
     <pkg>rdnb</pkg>
@@ -566,7 +533,6 @@
     <pkg>Rfacebook</pkg>
     <pkg>RFc</pkg>
     <pkg>rFDSN</pkg>
-    <pkg>rfigshare</pkg>
     <pkg>rfishbase</pkg>
     <pkg>rfisheries</pkg>
     <pkg>RForcecom</pkg>
@@ -637,7 +603,6 @@
     <pkg>tumblR</pkg>
     <pkg>twitteR</pkg>
     <pkg>ukgasapi</pkg>
-    <pkg>UNF</pkg>
     <pkg>USAboundaries</pkg>
     <pkg>UScancer</pkg>
     <pkg>ustyc</pkg>

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ CRAN Task View: Open Data
 |-----------------|--------------------------------------------------|
 | **Maintainer:** | Jaime Ashander, Scott Chamberlain, Thomas Leeper |
 | **Contact:**    | jashander at ucdavis.edu                         |
-| **Version:**    | 2017-02-16                                       |
+| **Version:**    | 2017-02-17                                       |
 | **URL:**        | <https://CRAN.R-project.org/view=OpenData>       |
 
-This Task View contains information about using R to obtain, parse, manipulate, create, and share open data. Much open data is available on the web, and the [WebTechnologies](http://cran.r-project.org/web/views/WebTechnologies.html) TaskView addresses how to obtain and parse web-based data. There is obvious overlap between the two TaskViews, so some packages are described on both. There is also a considerable amount of open data available as R packages on CRAN. We point readers to the [crandatapkgs](http://cran.rstudio.com/web/packages/crandatapkgs/index.html) package to obtain information about currently available open data in R packages.
+This Task View contains information about using R to obtain open data. Much open data is available on the web, and the [WebTechnologies](http://cran.r-project.org/web/views/WebTechnologies.html) TaskView generally addresses how to obtain and parse web-based data. There is obvious overlap between the two TaskViews, so some packages are described on both. There is also a considerable amount of open data available as R packages on CRAN. We point readers to the [crandatapkgs](http://cran.rstudio.com/web/packages/crandatapkgs/index.html) package to obtain information about currently available open data in R packages.
 
 Another key issue in a data-focused TaskView is the meaning of "open" data. This TaskView covers many types of data that come with varying degrees of usage restrictions from public domain (or CC-0) data that is usable for any purpose to "freely available" data that is available at no cost but may have licenses that are not strictly speaking "open". Users should investigate the terms of use and licensing of any data referenced here before using it for any particular application. Additionally, the view lists wrappers for paid APIs, as well as those that require an account but are not necessarily subscription only. These are marked ($) and (K) respectively.
 
@@ -19,56 +19,32 @@ If you have any comments or suggestions for additions, revisions, or improvement
 
 If you know of a web service, API, data source, or other online resource that is not yet supported by an R package, consider adding it to [the package development to do list on GitHub](https://github.com/ropensci/opendata/wiki/ToDo).
 
-Data Sharing and Archiving
---------------------------
+[Agriculture](#agriculture) | [Astronomy](#astronomy) | [Chemistry](#chemistry) | [Earth Science](#earth-science) | [Ecology/Evolution](#ecological-and-evolutionary-biology) | [Finance](#finance) | [Genes/Genomes](#genes-and-genomes) | [Geocoding](#geocoding) | [Google Analytics](#google-analytics) | [Google Web Services](#google-web-services) | [Government and Economics](#government) | [Literature/Text-mining](#literature-metadata-text-and-altmetrics) | [Maps](#maps) | [Marketing](#marketing) | [NCBI](#ncbi) | [News](#news) | [Other](#other) | [Public Health](#public-health) | [Social Media](#social-media) | [Social Science](#social-science) | [Sports](#sports) | [Web Analytics](#web-analytics) | [Wikipedia](#wikipedia) |
 
-Data sharing involves the dissemination of data in draft form or for a temporary period of time. rdrop2 ([GitHub](https://github.com/karthik/rdrop2)) is a Dropbox.com interface from R, providing access to a full suite of file operations, including dir/copy/move/delete operations, account information (including quotas) and the ability to upload and download files from any Dropbox account (K). [boxr](https://github.com/brendan-R/boxr) is a lightweight, high-level R interface for the [box.com API](https://developers.box.com/docs/) (K). [<span class="Ohat">RAmazonS3</span>](http://www.Omegahat.org/RAmazonS3/) provides an interface to the Amazon Simple Storage Service (S3) (K).
-
-Data archiving involves the production and dissemination of open data that is persistently accessible, typically in public repositories. The tools below may be useful for both archiving data and retrieving extant data from public archives.
-
--   [ckanr](https://github.com/ropensci/ckanr): A generic R client to interact with the CKAN data portal software API ( <a href="http://ckan.org/" class="uri" class="uri">http://ckan.org/</a>). Allows user to swap out the base URL to use any CKAN instance. [Source on GitHub](https://github.com/ropensci/ckanr).
--   [dataone](https://cran.rstudio.com/src/contrib/Archive/dataone/): Read/write access to data and metadata from the [DataONE network](https://www.dataone.org/) of Member Node data repositories.
--   [dvn](http://cran.rstudio.com/web/packages/dvn/index.html) ([GitHub](https://github.com/ropensci/dvn)) provides access to Dataverse Network repositories. [UNF](http://cran.rstudio.com/web/packages/UNF/index.html) implements the Universal Numeric Fingerprint, a format-independent data hashing algorithm used by Dataverse, to verify and cite a dataset.
--   [factualR](http://cran.rstudio.com/web/packages/factualR/index.html): Thin wrapper for the [Factual.com](https://factual.com/) server API.
--   The [<span class="Ohat">Rflickr</span>](http://www.Omegahat.org/Rflickr/) (not on CRAN) package provides an R interface to the Flickr photo management and sharing application Web service. (not on CRAN) (K)
--   [googlesheets](https://github.com/jennybc/googlesheets) (not on CRAN): Access private or public Google Sheets by title, key, or URL. Extract data or edit data. Create, delete, rename, copy, upload, or download spreadsheets and worksheets. [Source on GitHub](https://github.com/jennybc/googlesheets)
--   [gsheet](http://cran.rstudio.com/web/packages/gsheet/index.html): Download Google Sheets using just the sharing link. Spreadsheets can be downloaded as a data frame, or as plain text to parse manually. [Source on GitHub](https://github.com/maxconway/gsheet)
--   [imguR](http://cran.rstudio.com/web/packages/imguR/index.html) ([GitHub](https://github.com/leeper/imguR)): A package to share plots using the image hosting service [Imgur.com](https://www.imgur.com/). knitr also has a function `imgur_upload()` to load images from literate programming documents.
--   [infochimps](https://cran.rstudio.com/src/contrib/Archive/infochimps/) (archived on CRAN; [GitHub](https://github.com/drewconway/infochimps)) is an R wrapper for the infochimps.com API services, from [Drew Conway](http://drewconway.com/).
--   [internetarchive](https://github.com/ropensci/internetarchive) (not on CRAN): API client for internet archive metadata. [Source on GitHub](https://github.com/ropensci/internetarchive).
--   [jSonarR](http://cran.rstudio.com/web/packages/jSonarR/index.html): Enables users to access MongoDB by running queries and returning their results in R data frames. jSonarR uses data processing and conversion capabilities in the jSonar Analytics Platform and the [JSON Studio Gateway](http://www.jsonstudio.com), to convert JSON to a tabular format.
--   [OAIHarvester](http://cran.rstudio.com/web/packages/OAIHarvester/index.html): Harvest metadata using the Open Archives Initiative Protocol for Metadata Harvesting (OAI-PMH). [oai](http://cran.rstudio.com/web/packages/oai/index.html) is a more recent package for OAI.
--   [Quandl](http://cran.rstudio.com/web/packages/Quandl/index.html): A package that interacts directly with the [Quandl](https://www.quandl.com/) API to offer data in a number of formats usable in R, as well as the ability to upload and search.
--   [rdatamarket](http://cran.rstudio.com/web/packages/rdatamarket/index.html): Fetches data from DataMarket.com, either as timeseries in zoo form (dmseries) or as long-form data frames (dmlist).
--   [rerddap](https://github.com/ropensci/rerddap) (not on CRAN): A generic R client to interact with any ERDDAP instance, which is a special case of OPeNDAP ( <a href="https://en.wikipedia.org/wiki/OPeNDAP" class="uri" class="uri">https://en.wikipedia.org/wiki/OPeNDAP</a>), or *Open-source Project for a Network Data Access Protocol* . Allows user to swap out the base URL to use any ERDDAP instance. [Source on GitHub](https://github.com/ropensci/rerddap).
--   [rfigshare](http://cran.rstudio.com/web/packages/rfigshare/index.html): Programmatic interface for [Figshare.com](https://figshare.com/). [Source on GitHub](https://github.com/ropensci/rfigshare).
--   [rscribd](https://github.com/leeper/rscribd) (not on CRAN): API client for publishing documents to [Scribd](https://www.scribd.com/).
--   [RSocrata](https://cran.rstudio.com/src/contrib/Archive/RSocrata/): (temporarily archived on CRAN for email bounce) Provided with a Socrata dataset resource URL, or a Socrata SoDA web API query, returns an R data frame. Converts dates to POSIX format. Supports CSV and JSON. Manages throttling by Socrata.
-
-Web-based Open Data
--------------------
-
-[Agriculture](#agriculture) | [Astronomy](#astronomy) | [Business](#business) | [Chemistry](#chemistry) | [Climate](#climate) | [Earth Science](#earth-science) | [Ecology/Evolution](#ecological-and-evolutionary-biology) | [Finance](#finance) | [Genes/Genomes](#genes-and-genomes) | [Geocoding](#geocoding) | [Google Analytics](#google-analytics) | [Google Web Services](#google-web-services) | [Government and Economics](#government) | [Literature/Text-mining](#literature-metadata-text-and-altmetrics) | [Maps](#maps) | [Marketing](#marketing) | [NCBI](#ncbi) | [News](#news) | [Other](#other) | [Public Health](#public-health) | [Social Media](#social-media) | [Social Science](#social-science) | [Sports](#sports) | [Web Analytics](#web-analytics) | [Wikipedia](#wikipedia) |
-
-### Agriculture
+Agriculture
+-----------
 
 -   [cimis](https://cran.rstudio.com/src/contrib/Archive/cimis/): R package for retrieving data from CIMIS, the California Irrigation Management Information System. Available in CRAN archives only.
 -   [FAOSTAT](http://cran.rstudio.com/web/packages/FAOSTAT/index.html): The package hosts a list of functions to download, manipulate, construct and aggregate agricultural statistics provided by the FAOSTAT (Food and Agricultural Organization of the United Nations) database.
 
-### Astronomy
+Astronomy
+---------
 
 -   [RStars](http://cran.rstudio.com/web/packages/RStars/index.html): Star-API provides API access to the American Museum of Natural History's Digital Universe Data, including positions, luminosity, color, and other data on over 100,000 stars as well as constellations, exo-planets, clusters and others. [Source on GitHub](https://github.com/ropensci/RStars).
 
-### Business
+Business
+--------
 
 -   [forbesListR](https://github.com/abresler/forbesListR) (not on CRAN) offers access to a number of business-related datasets provided by Forbes.
 
-### Chemistry
+Chemistry
+---------
 
 -   [rpubchem](http://cran.rstudio.com/web/packages/rpubchem/index.html): Interface to the PubChem Collection.
 -   [webchem](http://cran.rstudio.com/web/packages/webchem/index.html): Retrieve chemical information from a suite of web APIs for chemical information. [Source on GitHub](https://github.com/ropensci/webchem)
 
-### Earth Science
+Earth Science
+-------------
 
 -   [dataRetrieval](http://cran.rstudio.com/web/packages/dataRetrieval/index.html): Collection of functions to help retrieve USGS data from either web services or user-provided data files. [on GitHub](https://github.com/USGS-R/dataRetrieval).
 -   [hddtools](http://cran.rstudio.com/web/packages/hddtools/index.html): Hydrological data discovery tools - accesses data from NASA, Global Runoff Data Centre, Top-Down modelling Working Group. [Source on GitHub](https://github.com/cvitolo/r_hddtools)
@@ -162,7 +138,8 @@ Web-based Open Data
 -   [rphylopic](https://github.com/sckott/rphylopic) (not on CRAN): An R client for [Phylopic.org](http://phylopic.org/), a databaes of free silhouettes of animals, embedded in a phylogenetic information framework. [Source on GitHub](https://github.com/sckott/rphylopic)
 -   [treebase](http://cran.rstudio.com/web/packages/treebase/index.html): An R package for discovery, access and manipulation of online phylogenies. [Source on GitHub](https://github.com/ropensci/treebase)
 
-### Finance
+Finance
+-------
 
 -   [dataonderivatives](http://cran.rstudio.com/web/packages/dataonderivatives/index.html) Post-GFC derivatives reforms have lifted the veil off over-the-counter (OTC) derivative markets. Swap Execution Facilities (SEFs) and Swap Data Repositories (SDRs) now publish data on swaps that are traded on or reported to those facilities (respectively). This package provides you the ability to get this data from supported sources.
 -   [Datastream2R](https://github.com/CharlesCara/Datastream2R) (not on CRAN): Another package for accessing the Datastream service. This package downloads data from the Thomson Reuters DataStream DWE server, which provides XML access to the Datastream database of economic and financial information.
@@ -183,7 +160,8 @@ Web-based Open Data
 -   [tseries](http://cran.rstudio.com/web/packages/tseries/index.html): Includes the `get.hist.quote` for historical financial data.
 -   [ustyc](http://cran.rstudio.com/web/packages/ustyc/index.html): US Treasury yield curve data retrieval. Development version on GitHub [here](https://github.com/mrbcuda/ustyc).
 
-### Genes and Genomes
+Genes and Genomes
+-----------------
 
 -   [aggRmesh](https://github.com/balcomes/aggRmesh): R client for the [National Center for Integrative Biomedical Informatics (NCIBI)](http://portal.ncibi.org/gateway/) data.
 -   [cgdsr](http://cran.rstudio.com/web/packages/cgdsr/index.html): R-Based API for accessing the MSKCC Cancer Genomics Data Server (CGDS).
@@ -197,20 +175,23 @@ Web-based Open Data
 -   [SoyNAM](http://cran.rstudio.com/web/packages/SoyNAM/index.html): Genomic and multi-environmental soybean data. Soybean Nested Association Mapping (SoyNAM) project dataset funded by the United Soybean Board (USB), pre-formatted for general analysis and genome-wide association analysis using the NAM package.
 -   NCBI EUtils web services: See the NCBI section
 
-### Geocoding
+Geocoding
+---------
 
 -   [geocodeHERE](http://cran.rstudio.com/web/packages/geocodeHERE/index.html): Wrapper for Nokia's [HERE](http://here.com/) geocoding API. API docs: <a href="https://developer.here.com/geocoder" class="uri" class="uri">https://developer.here.com/geocoder</a>. [Source on GitHub](https://github.com/corynissen/geocodeHERE)
 -   [ipapi](https://github.com/hrbrmstr/ipapi): Geolocate IPv4/6 addresses and/or domain names using the [ip-api.com](http://ip-api.com/) API. [Source on GitHub](https://github.com/hrbrmstr/ipapi)
 -   [openadds](https://github.com/sckott/openadds) is an R client for [OpenAddresses](http://openaddresses.io/) a free and open global address collection. [Source on GitHub](https://github.com/sckott/openadds)
 
-### Google Analytics
+Google Analytics
+----------------
 
 -   [ganalytics](https://github.com/jdeboer/ganalytics) (not on CRAN): Interface to [Google Analytics APIs](https://developers.google.com/analytics/). [Source on GitHub](https://github.com/jdeboer/ganalytics)
 -   [GAR](http://cran.rstudio.com/web/packages/GAR/index.html): Interface to [Google Analytics APIs](https://developers.google.com/analytics/). [Source on GitHub](https://github.com/andrewgeisler/GAR)
 -   [RGA](http://cran.rstudio.com/web/packages/RGA/index.html): Provides functions for accessing and retrieving data from the [Google Analytics APIs](https://developers.google.com/analytics/). Supports OAuth 2.0 authorization. Also, the RGA package provides a shiny app to explore data. There is another R package for the same service (RGoogleAnalytics); see above entry.
 -   [RGoogleAnalytics](http://cran.rstudio.com/web/packages/RGoogleAnalytics/index.html): Provides functions for accessing and retrieving data from the Google Analytics API. [Source on GitHub](https://github.com/Tatvic/RGoogleAnalytics/issues). There is another R package for the same service (RGA); see next entry.
 
-### Google Web Services
+Google Web Services
+-------------------
 
 -   [bigrquery](http://cran.rstudio.com/web/packages/bigrquery/index.html): An interface to Google's bigquery from R. [Source on GitHub](https://github.com/hadley/bigrquery) (K)
 -   [ganalytics](https://github.com/jdeboer/ganalytics) (not on CRAN): Interface to [Google Analytics APIs](https://developers.google.com/analytics/). [Source on GitHub](https://github.com/jdeboer/ganalytics) (K)
@@ -230,7 +211,8 @@ Web-based Open Data
 -   [translate](http://cran.rstudio.com/web/packages/translate/index.html): Bindings for the Google Translate API v2
 -   [translateR](http://cran.rstudio.com/web/packages/translateR/index.html) provides bindings for both Google and Microsoft translation APIs.
 
-### Government
+Government
+----------
 
 There are a very large number of packages providing access to government data. Here is a list of these packages, arranged by country and/or other jurisdiction.
 
@@ -280,7 +262,8 @@ There are a very large number of packages providing access to government data. H
     -   [psData](http://cran.rstudio.com/web/packages/psData/index.html) ([GitHub](https://github.com/christophergandrud/psData/)) provides access to various commonly used political science datasets, especially those providing country-level, comparative data.
     -   World Bank: [wbstats](http://cran.rstudio.com/web/packages/wbstats/index.html) can extract data from the [World Bank Data API](http://data.worldbank.org/developers/api-overview) and the [World Bank Data Catalog API](http://data.worldbank.org/developers/data-catalog-api). [WDI](http://cran.rstudio.com/web/packages/WDI/index.html) can search, extract and format data from the World Bank's World Development Indicators.
 
-### Literature, Metadata, Text, and Altmetrics
+Literature, Metadata, Text, and Altmetrics
+------------------------------------------
 
 -   [alm](http://cran.rstudio.com/web/packages/alm/index.html): R wrapper to the almetrics API platform developed by PLoS.
 -   [aRxiv](http://cran.rstudio.com/web/packages/aRxiv/index.html) ([GitHub](https://github.com/ropensci/aRxiv)): An R client for the arXiv API, a repository of electronic preprints for computer science, mathematics, physics, quantitative biology, quantitative finance, and statistics.
@@ -305,7 +288,8 @@ There are a very large number of packages providing access to government data. H
 -   [tm.plugin.webmining](http://cran.rstudio.com/web/packages/tm.plugin.webmining/index.html): Extensible text retrieval framework for news feeds in XML (RSS, ATOM) and JSON formats. Currently, the following feeds are implemented: Google Blog Search, Google Finance, Google News, NYTimes Article Search, Reuters News Feed, Yahoo Finance and Yahoo Inplay.
 -   [biorxivr](http://cran.rstudio.com/web/packages/biorxivr/index.html): interface with bioRxiv preprint server
 
-### Maps
+Maps
+----
 
 -   [FedData](http://cran.rstudio.com/web/packages/FedData/index.html) can download geospatial data from a number of U.S. and international data sources.
 -   [ggmap](http://cran.rstudio.com/web/packages/ggmap/index.html): Allows for the easy visualization of spatial data and models on top of Google Maps, OpenStreetMaps, Stamen Maps, or CloudMade Maps using ggplot2.
@@ -322,7 +306,8 @@ There are a very large number of packages providing access to government data. H
 -   [tigris](https://github.com/walkerke/tigris) (not on CRAN) can read US Census Bureau TIGRIS shapefiles.
 -   [USAboundaries](http://cran.rstudio.com/web/packages/USAboundaries/index.html) spatial objects with the boundaries of states or counties in the United States of America from 1629 to 2000 (from the Atlas of Historical County Boundaries).
 
-### NCBI
+NCBI
+----
 
 -   [hoardeR](http://cran.rstudio.com/web/packages/hoardeR/index.html): Information retrieval from NCBI databases, with main focus on Blast.
 -   [NCBI2R](http://cran.rstudio.com/src/contrib/Archive/NCBI2R/): Annotates lists of SNPs and/or genes, with current information from NCBI. The CRAN version is archived.
@@ -330,13 +315,15 @@ There are a very large number of packages providing access to government data. H
 -   [reutils](http://cran.rstudio.com/web/packages/reutils/index.html) ([GitHub](https://github.com/gschofl/reutils)): Interface with NCBI databases such as PubMed, Genbank, or GEO via the Entrez Programming Utilities (EUtils).
 -   [RISmed](http://cran.rstudio.com/web/packages/RISmed/index.html): Download content from NCBI databases. Intended for analyses of NCBI database content, not reference management. See rpubmed for more literature oriented stuff from NCBI.
 
-### News
+News
+----
 
 -   [GuardianR](http://cran.rstudio.com/web/packages/GuardianR/index.html): Provides an interface to the Open Platform's Content API of the Guardian Media Group. It retrieves content from news outlets The Observer, The Guardian, and guardian.co.uk from 1999 to current day. [rdian](http://cran.rstudio.com/web/packages/rdian/index.html) ([GitHub](https://github.com/ironholds/rdian)) is another Guardian API client.
 -   [rtimes](https://github.com/ropengov/rtimes) (not on CRAN): R client for the New York Times APIs, including the Congress, Article Search, Campaign Finance, and Geographic APIs.
 -   *ZEIT*: [diezeit](http://cran.rstudio.com/web/packages/diezeit/index.html) waps the ZEIT online content API (K).
 
-### Other
+Other
+-----
 
 -   [datamart](http://cran.rstudio.com/web/packages/datamart/index.html): Provides an S4 infrastructure for unified handling of internal datasets and web based data sources. Examples include dbpedia, eurostat and sourceforge.
 -   [genderizeR](http://cran.rstudio.com/web/packages/genderizeR/index.html): Uses the genderize.io API to predict gender from first names extracted from a text vector. [Source on GitHub](https://github.com/kalimu/genderizeR)
@@ -352,7 +339,8 @@ There are a very large number of packages providing access to government data. H
 -   [TMDb](http://cran.rstudio.com/web/packages/TMDb/index.html) can retrieve data from [The Movie Database](https://www.themoviedb.org).
 -   [zendeskR](http://cran.rstudio.com/web/packages/zendeskR/index.html): This package provides an R wrapper for the Zendesk API. ($)
 
-### Public Health
+Public Health
+-------------
 
 -   [cdcfluview](https://github.com/hrbrmstr/cdcfluview): (not on CRAN) R client for CDC FluView data (WHO and ILINet).
 -   [nhanesA](http://cran.rstudio.com/web/packages/nhanesA/index.html) Utility to retrieve data from the National Health and Nutrition Examination Survey (NHANES).
@@ -363,7 +351,8 @@ There are a very large number of packages providing access to government data. H
 -   [vaers](https://gitlab.com/iembry/vaers) (not on CRAN) provides U.S. vaccine adverse event data from the [VAERS](https://vaers.hhs.gov/index) vaccine surveillance program. [vaersvax](http://cran.rstudio.com/web/packages/vaersvax/index.html) provides a subset a subset of these data for three months of 2016. [vaersNDvax](http://cran.rstudio.com/web/packages/vaersNDvax/index.html) provides non-domestic data for the same period.
 -   WHO: [WHO](http://cran.rstudio.com/web/packages/WHO/index.html) ([GitHub](https://www.github.com/expersso/WHO)) provides an interface to the [World Health Organization](http://www.who.int/) API. [rgho](http://cran.rstudio.com/web/packages/rgho/index.html) ([GitHub](https://github.com/pierucci/rgho)) connects to the WHO Global Health Observatory data.
 
-### Social media
+Social media
+------------
 
 -   *Facebook*: [Rfacebook](http://cran.rstudio.com/web/packages/Rfacebook/index.html) provides an interface to the Facebook API. (K)
 -   *Google+*: [plusser](http://cran.rstudio.com/web/packages/plusser/index.html) has been designed to to facilitate the retrieval of Google+ profiles, pages and posts. It also provides search facilities. Currently a Google+ API key is required for accessing Google+ data. [tuber](https://github.com/soodoku/tuber) provides bindings for YouTube API. Only on Github for now. (K)
@@ -374,7 +363,8 @@ There are a very large number of packages providing access to government data. H
 -   [SocialMediaLab](http://cran.rstudio.com/web/packages/SocialMediaLab/index.html) provides a convenient wrapper around many other social media clients and enables the construction of network structures from those data.
 -   [SocialMediaMineR](http://cran.rstudio.com/web/packages/SocialMediaMineR/index.html) is an analytic tool that returns information about the popularity of a URL on social media sites.
 
-### Social science
+Social science
+--------------
 
 -   [asdfree: analyze survey data for free](http://www.asdfree.com/) (not a package) provides lots of code examples for analyzing survey data in R. Also on [github](https://github.com/ajdamico/usgsd).
 -   [brewdata](http://cran.rstudio.com/web/packages/brewdata/index.html) Retrieves and parses graduate admissions survey data from the [Grad Cafe website](http://thegradcafe.com).
@@ -388,7 +378,8 @@ There are a very large number of packages providing access to government data. H
 -   [wordbankr](http://cran.rstudio.com/web/packages/wordbankr/index.html) ([GitHub](https://github.com/langcog/wordbankr)) connects to [Wordbank](http://wordbank.stanford.edu/), a database of childrens' developmental vocabulary.
 -   The [<span class="Ohat">Zillow</span>](http://www.Omegahat.org/Zillow/) (not on CRAN) package provides an R interface to the [Zillow](http://www.zillow.com/) Web Service API. It allows one to get the Zillow estimate for the price of a particular property specified by street address and ZIP code (or city and state), to find information (e.g. size of property and lot, number of bedrooms and bathrooms, year built.) about a given property, and to get comparable properties.
 
-### Sports
+Sports
+------
 
 -   [abettor](https://github.com/phillc73/abettor) (not on CRAN): Online betting exchange, Betfair, API wrapper in R. (K)
 -   [ballr](https://github.com/rtelmore/ballr) (not on CRAN) is a client for [Basketball-Reference.com](http://www.basketball-reference.com/).
@@ -404,7 +395,8 @@ There are a very large number of packages providing access to government data. H
 -   [retrosheet](http://cran.rstudio.com/web/packages/retrosheet/index.html) ([Github](https://github.com/rmscriven/retrosheet)) retrieves single-season baseball statistics from <a href="http://www.retrosheet.org" class="uri" class="uri">http://www.retrosheet.org</a>.
 -   [yorkr](http://cran.rstudio.com/web/packages/yorkr/index.html) provides access to cricket data from [Cricsheet](http://cricsheet.org).
 
-### Web Analytics
+Web Analytics
+-------------
 
 -   [GTrendsR](https://github.com/dvanclev/GTrendsR) (not on CRAN): R functions to perform and display Google Trends queries. Another Github package ([rGtrends](https://github.com/emhart/rGtrends)) is now deprecated, but supported a previous version of Google Trends and may still be useful for developers.
 -   rgauges ([Archived on CRAN](https://cran.r-project.org/src/contrib/Archive/rgauges)) This package provides functions to interact with the Gaug.es API. Gaug.es is a web analytics service, like Google analytics. You have to have a Gaug.es account to use this package. ($) (K)
@@ -413,7 +405,8 @@ There are a very large number of packages providing access to government data. H
 -   [<span class="Ohat">RGoogleTrends</span>](http://www.Omegahat.org/RGoogleTrends/) (not on CRAN) provides programmatic access to Google Trends data. This is information about the popularity of a particular query.
 -   [RSiteCatalyst](http://cran.rstudio.com/web/packages/RSiteCatalyst/index.html): Functions for accessing the Adobe Analytics (Omniture SiteCatalyst) Reporting API.
 
-### Wikipedia/Wikimedia
+Wikipedia/Wikimedia
+-------------------
 
 -   [wikipediatrend](https://github.com/petermeissner/wikipediatrend) (removed from CRAN): Provides access to Wikipedia page access statistics.
 -   [WikipediR](http://cran.rstudio.com/web/packages/WikipediR/index.html): WikipediR is a wrapper for the MediaWiki API, aimed particularly at the Wikimedia 'production' wikis, such as Wikipedia. [Source on GitHub](https://github.com/Ironholds/WikipediR)
@@ -452,7 +445,6 @@ There are a very large number of packages providing access to government data. H
 -   [dataRetrieval](http://cran.rstudio.com/web/packages/dataRetrieval/index.html)
 -   [diezeit](http://cran.rstudio.com/web/packages/diezeit/index.html)
 -   [dismo](http://cran.rstudio.com/web/packages/dismo/index.html)
--   [dvn](http://cran.rstudio.com/web/packages/dvn/index.html)
 -   [easyPubMed](http://cran.rstudio.com/web/packages/easyPubMed/index.html)
 -   [ecb](http://cran.rstudio.com/web/packages/ecb/index.html)
 -   [ecoengine](http://cran.rstudio.com/web/packages/ecoengine/index.html)
@@ -466,7 +458,6 @@ There are a very large number of packages providing access to government data. H
 -   [epidata](http://cran.rstudio.com/web/packages/epidata/index.html)
 -   [estatapi](http://cran.rstudio.com/web/packages/estatapi/index.html)
 -   [eurostat](http://cran.rstudio.com/web/packages/eurostat/index.html)
--   [factualR](http://cran.rstudio.com/web/packages/factualR/index.html)
 -   [FAOSTAT](http://cran.rstudio.com/web/packages/FAOSTAT/index.html)
 -   [fbRanks](http://cran.rstudio.com/web/packages/fbRanks/index.html)
 -   [FedData](http://cran.rstudio.com/web/packages/FedData/index.html)
@@ -483,7 +474,6 @@ There are a very large number of packages providing access to government data. H
 -   [ggmap](http://cran.rstudio.com/web/packages/ggmap/index.html)
 -   [googleVis](http://cran.rstudio.com/web/packages/googleVis/index.html)
 -   [govStatJPN](http://cran.rstudio.com/web/packages/govStatJPN/index.html)
--   [gsheet](http://cran.rstudio.com/web/packages/gsheet/index.html)
 -   [GSODR](http://cran.rstudio.com/web/packages/GSODR/index.html)
 -   [GuardianR](http://cran.rstudio.com/web/packages/GuardianR/index.html)
 -   [gutenbergr](http://cran.rstudio.com/web/packages/gutenbergr/index.html)
@@ -496,9 +486,7 @@ There are a very large number of packages providing access to government data. H
 -   [icpsrdata](http://cran.rstudio.com/web/packages/icpsrdata/index.html)
 -   [idbr](http://cran.rstudio.com/web/packages/idbr/index.html)
 -   [imfr](http://cran.rstudio.com/web/packages/imfr/index.html)
--   [imguR](http://cran.rstudio.com/web/packages/imguR/index.html)
 -   [inegiR](http://cran.rstudio.com/web/packages/inegiR/index.html)
--   [jSonarR](http://cran.rstudio.com/web/packages/jSonarR/index.html)
 -   [kokudosuuchi](http://cran.rstudio.com/web/packages/kokudosuuchi/index.html)
 -   [leafletR](http://cran.rstudio.com/web/packages/leafletR/index.html)
 -   [lumendb](http://cran.rstudio.com/web/packages/lumendb/index.html)
@@ -513,8 +501,6 @@ There are a very large number of packages providing access to government data. H
 -   [neotoma](http://cran.rstudio.com/web/packages/neotoma/index.html)
 -   [nhanesA](http://cran.rstudio.com/web/packages/nhanesA/index.html)
 -   [nhlscrapr](http://cran.rstudio.com/web/packages/nhlscrapr/index.html)
--   [oai](http://cran.rstudio.com/web/packages/oai/index.html)
--   [OAIHarvester](http://cran.rstudio.com/web/packages/OAIHarvester/index.html)
 -   [OECD](http://cran.rstudio.com/web/packages/OECD/index.html)
 -   [okmesonet](http://cran.rstudio.com/web/packages/okmesonet/index.html)
 -   [olctools](http://cran.rstudio.com/web/packages/olctools/index.html)
@@ -541,7 +527,6 @@ There are a very large number of packages providing access to government data. H
 -   [pubmed.mineR](http://cran.rstudio.com/web/packages/pubmed.mineR/index.html)
 -   [pvsR](http://cran.rstudio.com/web/packages/pvsR/index.html)
 -   [pxweb](http://cran.rstudio.com/web/packages/pxweb/index.html)
--   [Quandl](http://cran.rstudio.com/web/packages/Quandl/index.html)
 -   [quantmod](http://cran.rstudio.com/web/packages/quantmod/index.html)
 -   [RAdwords](http://cran.rstudio.com/web/packages/RAdwords/index.html)
 -   [raincpc](http://cran.rstudio.com/web/packages/raincpc/index.html)
@@ -557,7 +542,6 @@ There are a very large number of packages providing access to government data. H
 -   [rclinicaltrials](http://cran.rstudio.com/web/packages/rclinicaltrials/index.html)
 -   [Rcolombos](http://cran.rstudio.com/web/packages/Rcolombos/index.html)
 -   [RCryptsy](http://cran.rstudio.com/web/packages/RCryptsy/index.html)
--   [rdatamarket](http://cran.rstudio.com/web/packages/rdatamarket/index.html)
 -   [rdefra](http://cran.rstudio.com/web/packages/rdefra/index.html)
 -   [rdian](http://cran.rstudio.com/web/packages/rdian/index.html)
 -   [rdnb](http://cran.rstudio.com/web/packages/rdnb/index.html)
@@ -574,7 +558,6 @@ There are a very large number of packages providing access to government data. H
 -   [Rfacebook](http://cran.rstudio.com/web/packages/Rfacebook/index.html)
 -   [RFc](http://cran.rstudio.com/web/packages/RFc/index.html)
 -   [rFDSN](http://cran.rstudio.com/web/packages/rFDSN/index.html)
--   [rfigshare](http://cran.rstudio.com/web/packages/rfigshare/index.html)
 -   [rfishbase](http://cran.rstudio.com/web/packages/rfishbase/index.html)
 -   [rfisheries](http://cran.rstudio.com/web/packages/rfisheries/index.html)
 -   [RForcecom](http://cran.rstudio.com/web/packages/RForcecom/index.html)
@@ -645,7 +628,6 @@ There are a very large number of packages providing access to government data. H
 -   [tumblR](http://cran.rstudio.com/web/packages/tumblR/index.html)
 -   [twitteR](http://cran.rstudio.com/web/packages/twitteR/index.html)
 -   [ukgasapi](http://cran.rstudio.com/web/packages/ukgasapi/index.html)
--   [UNF](http://cran.rstudio.com/web/packages/UNF/index.html)
 -   [USAboundaries](http://cran.rstudio.com/web/packages/USAboundaries/index.html)
 -   [UScancer](http://cran.rstudio.com/web/packages/UScancer/index.html)
 -   [ustyc](http://cran.rstudio.com/web/packages/ustyc/index.html)

--- a/data_sharing.md
+++ b/data_sharing.md
@@ -1,0 +1,25 @@
+
+## Data Sharing and Archiving ##
+
+Data sharing involves the dissemination of data in draft form or for a temporary period of time. rdrop2 ([GitHub](https://github.com/karthik/rdrop2)) is a Dropbox.com interface from R, providing access to a full suite of file operations, including dir/copy/move/delete operations, account information (including quotas) and the ability to upload and download files from any Dropbox account (K). [boxr](https://github.com/brendan-R/boxr) is a lightweight, high-level R interface for the [box.com API](https://developers.box.com/docs/) (K). <ohat>RAmazonS3</ohat> provides an interface to the Amazon Simple Storage Service (S3) (K).
+
+Data archiving involves the production and dissemination of open data that is persistently accessible, typically in public repositories. The tools below may be useful for both archiving data and retrieving extant data from public archives.
+
+-   [ckanr](https://github.com/ropensci/ckanr): A generic R client to interact with the CKAN data portal software API (<http://ckan.org/>). Allows user to swap out the base URL to use any CKAN instance. [Source on GitHub](https://github.com/ropensci/ckanr).
+-   [dataone](https://cran.rstudio.com/src/contrib/Archive/dataone/): Read/write access to data and metadata from the [DataONE network](https://www.dataone.org/) of Member Node data repositories.
+-   <pkg>dvn</pkg> ([GitHub](https://github.com/ropensci/dvn)) provides access to Dataverse Network repositories. <pkg>UNF</pkg> implements the Universal Numeric Fingerprint, a format-independent data hashing algorithm used by Dataverse, to verify and cite a dataset.
+-   <pkg>factualR</pkg>: Thin wrapper for the [Factual.com](https://factual.com/) server API.
+-   The <ohat>Rflickr</ohat> (not on CRAN) package provides an R interface to the Flickr photo management and sharing application Web service. (not on CRAN) (K)
+-   [googlesheets](https://github.com/jennybc/googlesheets) (not on CRAN): Access private or public Google Sheets by title, key, or URL. Extract data or edit data. Create, delete, rename, copy, upload, or download spreadsheets and worksheets. [Source on GitHub](https://github.com/jennybc/googlesheets)
+-   <pkg>gsheet</pkg>: Download Google Sheets using just the sharing link. Spreadsheets can be downloaded as a data frame, or as plain text to parse manually. [Source on GitHub](https://github.com/maxconway/gsheet)
+-   <pkg>imguR</pkg> ([GitHub](https://github.com/leeper/imguR)): A package to share plots using the image hosting service [Imgur.com](https://www.imgur.com/). knitr also has a function `imgur_upload()` to load images from literate programming documents.
+-   [infochimps](https://cran.rstudio.com/src/contrib/Archive/infochimps/) (archived on CRAN; [GitHub](https://github.com/drewconway/infochimps)) is an R wrapper for the infochimps.com API services, from [Drew Conway](http://drewconway.com/).
+-   [internetarchive](https://github.com/ropensci/internetarchive) (not on CRAN): API client for internet archive metadata. [Source on GitHub](https://github.com/ropensci/internetarchive).
+-   <pkg>jSonarR</pkg>: Enables users to access MongoDB by running queries and returning their results in R data frames. jSonarR uses data processing and conversion capabilities in the jSonar Analytics Platform and the [JSON Studio Gateway](http://www.jsonstudio.com), to convert JSON to a tabular format.
+-   <pkg>OAIHarvester</pkg>: Harvest metadata using the Open Archives Initiative Protocol for Metadata Harvesting (OAI-PMH). <pkg>oai</pkg> is a more recent package for OAI.
+-   <pkg>Quandl</pkg>: A package that interacts directly with the [Quandl](https://www.quandl.com/) API to offer data in a number of formats usable in R, as well as the ability to upload and search.
+-   <pkg>rdatamarket</pkg>: Fetches data from DataMarket.com, either as timeseries in zoo form (dmseries) or as long-form data frames (dmlist).
+-   [rerddap](https://github.com/ropensci/rerddap) (not on CRAN): A generic R client to interact with any ERDDAP instance, which is a special case of OPeNDAP (<https://en.wikipedia.org/wiki/OPeNDAP>), or *Open-source Project for a Network Data Access Protocol*. Allows user to swap out the base URL to use any ERDDAP instance. [Source on GitHub](https://github.com/ropensci/rerddap).
+-   <pkg>rfigshare</pkg>: Programmatic interface for [Figshare.com](https://figshare.com/). [Source on GitHub](https://github.com/ropensci/rfigshare).
+-   [rscribd](https://github.com/leeper/rscribd) (not on CRAN): API client for publishing documents to [Scribd](https://www.scribd.com/).
+-   [RSocrata](https://cran.rstudio.com/src/contrib/Archive/RSocrata/): (temporarily archived on CRAN for email bounce) Provided with a Socrata dataset resource URL, or a Socrata SoDA web API query, returns an R data frame. Converts dates to POSIX format. Supports CSV and JSON. Manages throttling by Socrata.

--- a/opendata.md
+++ b/opendata.md
@@ -1,4 +1,4 @@
-This Task View contains information about using R to obtain, parse, manipulate, create, and share open data. Much open data is available on the web, and the [WebTechnologies](http://cran.r-project.org/web/views/WebTechnologies.html) TaskView addresses how to obtain and parse web-based data. There is obvious overlap between the two TaskViews, so some packages are described on both. There is also a considerable amount of open data available as R packages on CRAN. We point readers to the <pkg>crandatapkgs</pkg> package to obtain information about currently available open data in R packages.
+This Task View contains information about using R to obtain open data. Much open data is available on the web, and the [WebTechnologies](http://cran.r-project.org/web/views/WebTechnologies.html) TaskView generally addresses how to obtain and parse web-based data. There is obvious overlap between the two TaskViews, so some packages are described on both. There is also a considerable amount of open data available as R packages on CRAN. We point readers to the <pkg>crandatapkgs</pkg> package to obtain information about currently available open data in R packages.
 
 Another key issue in a data-focused TaskView is the meaning of "open" data. This TaskView covers many types of data that come with varying degrees of usage restrictions from public domain (or CC-0) data that is usable for any purpose to "freely available" data that is available at no cost but may have licenses that are not strictly speaking "open". Users should investigate the terms of use and licensing of any data referenced here before using it for any particular application. Additionally, the view lists wrappers for paid APIs, as well as those that require an account but are not necessarily subscription only. These are marked (\$) and (K) respectively.
 
@@ -6,54 +6,27 @@ If you have any comments or suggestions for additions, revisions, or improvement
 
 If you know of a web service, API, data source, or other online resource that is not yet supported by an R package, consider adding it to [the package development to do list on GitHub](https://github.com/ropensci/opendata/wiki/ToDo).
 
-## Data Sharing and Archiving ##
+[Agriculture](#agriculture) | [Astronomy](#astronomy) | [Chemistry](#chemistry) | [Earth Science](#earth-science) | [Ecology/Evolution](#ecological-and-evolutionary-biology) | [Finance](#finance) | [Genes/Genomes](#genes-and-genomes) | [Geocoding](#geocoding) | [Google Analytics](#google-analytics) | [Google Web Services](#google-web-services) | [Government and Economics](#government) | [Literature/Text-mining](#literature-metadata-text-and-altmetrics) | [Maps](#maps) | [Marketing](#marketing) | [NCBI](#ncbi) | [News](#news) | [Other](#other) | [Public Health](#public-health) | [Social Media](#social-media) | [Social Science](#social-science) | [Sports](#sports) | [Web Analytics](#web-analytics) | [Wikipedia](#wikipedia) |
 
-Data sharing involves the dissemination of data in draft form or for a temporary period of time. rdrop2 ([GitHub](https://github.com/karthik/rdrop2)) is a Dropbox.com interface from R, providing access to a full suite of file operations, including dir/copy/move/delete operations, account information (including quotas) and the ability to upload and download files from any Dropbox account (K). [boxr](https://github.com/brendan-R/boxr) is a lightweight, high-level R interface for the [box.com API](https://developers.box.com/docs/) (K). <ohat>RAmazonS3</ohat> provides an interface to the Amazon Simple Storage Service (S3) (K).
-
-Data archiving involves the production and dissemination of open data that is persistently accessible, typically in public repositories. The tools below may be useful for both archiving data and retrieving extant data from public archives.
-
--   [ckanr](https://github.com/ropensci/ckanr): A generic R client to interact with the CKAN data portal software API (<http://ckan.org/>). Allows user to swap out the base URL to use any CKAN instance. [Source on GitHub](https://github.com/ropensci/ckanr).
--   [dataone](https://cran.rstudio.com/src/contrib/Archive/dataone/): Read/write access to data and metadata from the [DataONE network](https://www.dataone.org/) of Member Node data repositories.
--   <pkg>dvn</pkg> ([GitHub](https://github.com/ropensci/dvn)) provides access to Dataverse Network repositories. <pkg>UNF</pkg> implements the Universal Numeric Fingerprint, a format-independent data hashing algorithm used by Dataverse, to verify and cite a dataset.
--   <pkg>factualR</pkg>: Thin wrapper for the [Factual.com](https://factual.com/) server API.
--   The <ohat>Rflickr</ohat> (not on CRAN) package provides an R interface to the Flickr photo management and sharing application Web service. (not on CRAN) (K)
--   [googlesheets](https://github.com/jennybc/googlesheets) (not on CRAN): Access private or public Google Sheets by title, key, or URL. Extract data or edit data. Create, delete, rename, copy, upload, or download spreadsheets and worksheets. [Source on GitHub](https://github.com/jennybc/googlesheets)
--   <pkg>gsheet</pkg>: Download Google Sheets using just the sharing link. Spreadsheets can be downloaded as a data frame, or as plain text to parse manually. [Source on GitHub](https://github.com/maxconway/gsheet)
--   <pkg>imguR</pkg> ([GitHub](https://github.com/leeper/imguR)): A package to share plots using the image hosting service [Imgur.com](https://www.imgur.com/). knitr also has a function `imgur_upload()` to load images from literate programming documents.
--   [infochimps](https://cran.rstudio.com/src/contrib/Archive/infochimps/) (archived on CRAN; [GitHub](https://github.com/drewconway/infochimps)) is an R wrapper for the infochimps.com API services, from [Drew Conway](http://drewconway.com/).
--   [internetarchive](https://github.com/ropensci/internetarchive) (not on CRAN): API client for internet archive metadata. [Source on GitHub](https://github.com/ropensci/internetarchive).
--   <pkg>jSonarR</pkg>: Enables users to access MongoDB by running queries and returning their results in R data frames. jSonarR uses data processing and conversion capabilities in the jSonar Analytics Platform and the [JSON Studio Gateway](http://www.jsonstudio.com), to convert JSON to a tabular format.
--   <pkg>OAIHarvester</pkg>: Harvest metadata using the Open Archives Initiative Protocol for Metadata Harvesting (OAI-PMH). <pkg>oai</pkg> is a more recent package for OAI.
--   <pkg>Quandl</pkg>: A package that interacts directly with the [Quandl](https://www.quandl.com/) API to offer data in a number of formats usable in R, as well as the ability to upload and search.
--   <pkg>rdatamarket</pkg>: Fetches data from DataMarket.com, either as timeseries in zoo form (dmseries) or as long-form data frames (dmlist).
--   [rerddap](https://github.com/ropensci/rerddap) (not on CRAN): A generic R client to interact with any ERDDAP instance, which is a special case of OPeNDAP (<https://en.wikipedia.org/wiki/OPeNDAP>), or *Open-source Project for a Network Data Access Protocol*. Allows user to swap out the base URL to use any ERDDAP instance. [Source on GitHub](https://github.com/ropensci/rerddap).
--   <pkg>rfigshare</pkg>: Programmatic interface for [Figshare.com](https://figshare.com/). [Source on GitHub](https://github.com/ropensci/rfigshare).
--   [rscribd](https://github.com/leeper/rscribd) (not on CRAN): API client for publishing documents to [Scribd](https://www.scribd.com/).
--   [RSocrata](https://cran.rstudio.com/src/contrib/Archive/RSocrata/): (temporarily archived on CRAN for email bounce) Provided with a Socrata dataset resource URL, or a Socrata SoDA web API query, returns an R data frame. Converts dates to POSIX format. Supports CSV and JSON. Manages throttling by Socrata.
-
-## Web-based Open Data ##
-
-[Agriculture](#agriculture) | [Astronomy](#astronomy) | [Business](#business) | [Chemistry](#chemistry) | [Climate](#climate) | [Earth Science](#earth-science) | [Ecology/Evolution](#ecological-and-evolutionary-biology) | [Finance](#finance) | [Genes/Genomes](#genes-and-genomes) | [Geocoding](#geocoding) | [Google Analytics](#google-analytics) | [Google Web Services](#google-web-services) | [Government and Economics](#government) | [Literature/Text-mining](#literature-metadata-text-and-altmetrics) | [Maps](#maps) | [Marketing](#marketing) | [NCBI](#ncbi) | [News](#news) | [Other](#other) | [Public Health](#public-health) | [Social Media](#social-media) | [Social Science](#social-science) | [Sports](#sports) | [Web Analytics](#web-analytics) | [Wikipedia](#wikipedia) |
-
-###Agriculture###
+##Agriculture##
 
 -   [cimis](https://cran.rstudio.com/src/contrib/Archive/cimis/): R package for retrieving data from CIMIS, the California Irrigation Management Information System. Available in CRAN archives only.
 -   <pkg>FAOSTAT</pkg>: The package hosts a list of functions to download, manipulate, construct and aggregate agricultural statistics provided by the FAOSTAT (Food and Agricultural Organization of the United Nations) database.
 
-###Astronomy###
+##Astronomy##
 
 -   <pkg>RStars</pkg>: Star-API provides API access to the American Museum of Natural History's Digital Universe Data, including positions, luminosity, color, and other data on over 100,000 stars as well as constellations, exo-planets, clusters and others. [Source on GitHub](https://github.com/ropensci/RStars).
 
-###Business###
+##Business##
 
 -   [forbesListR](https://github.com/abresler/forbesListR) (not on CRAN) offers access to a number of business-related datasets provided by Forbes.
 
-###Chemistry###
+##Chemistry##
 
 -   <pkg>rpubchem</pkg>: Interface to the PubChem Collection.
 -   <pkg>webchem</pkg>: Retrieve chemical information from a suite of web APIs for chemical information. [Source on GitHub](https://github.com/ropensci/webchem)
 
-###Earth Science###
+##Earth Science##
 
 -   <pkg>dataRetrieval</pkg>: Collection of functions to help retrieve USGS data from either web services or user-provided data files. [on GitHub](https://github.com/USGS-R/dataRetrieval).
 -   <pkg>hddtools</pkg>: Hydrological data discovery tools - accesses data from NASA, Global Runoff Data Centre, Top-Down modelling Working Group. [Source on GitHub](https://github.com/cvitolo/r_hddtools)
@@ -149,7 +122,7 @@ Data archiving involves the production and dissemination of open data that is pe
 -   <pkg>treebase</pkg>: An R package for discovery, access and manipulation of online phylogenies. [Source on GitHub](https://github.com/ropensci/treebase)
 
 
-###Finance###
+##Finance##
 
 -   <pkg>dataonderivatives</pkg> Post-GFC derivatives reforms have lifted the veil off over-the-counter (OTC) derivative markets. Swap Execution Facilities (SEFs) and Swap Data Repositories (SDRs) now publish data on swaps that are traded on or reported to those facilities (respectively). This package provides you the ability to get this data from supported sources. 
 -   [Datastream2R](https://github.com/CharlesCara/Datastream2R) (not on CRAN): Another package for accessing the Datastream service. This package downloads data from the Thomson Reuters DataStream DWEserver, which provides XML access to the Datastream database of economic and financial information.
@@ -170,7 +143,7 @@ Data archiving involves the production and dissemination of open data that is pe
 -   <pkg>tseries</pkg>: Includes the `get.hist.quote` for historical financial data.
 -   <pkg>ustyc</pkg>: US Treasury yield curve data retrieval. Development version on GitHub [here](https://github.com/mrbcuda/ustyc).
 
-###Genes and Genomes###
+##Genes and Genomes##
 
 -   [aggRmesh](https://github.com/balcomes/aggRmesh): R client for the [National Center for Integrative Biomedical Informatics (NCIBI)](http://portal.ncibi.org/gateway/) data.
 -   <pkg>cgdsr</pkg>: R-Based API for accessing the MSKCC Cancer Genomics Data Server (CGDS).
@@ -184,20 +157,20 @@ Data archiving involves the production and dissemination of open data that is pe
 -   <pkg>SoyNAM</pkg>: Genomic and multi-environmental soybean data. Soybean Nested Association Mapping (SoyNAM) project dataset funded by the United Soybean Board (USB), pre-formatted for general analysis and genome-wide association analysis using the NAM package.
 -   NCBI EUtils web services: See the NCBI section
 
-###Geocoding###
+##Geocoding##
 
 -   <pkg>geocodeHERE</pkg>: Wrapper for Nokia's [HERE](http://here.com/) geocoding API. API docs: <https://developer.here.com/geocoder>. [Source on GitHub](https://github.com/corynissen/geocodeHERE)
 -   [ipapi](https://github.com/hrbrmstr/ipapi): Geolocate IPv4/6 addresses and/or domain names using the [ip-api.com](http://ip-api.com/) API. [Source on GitHub](https://github.com/hrbrmstr/ipapi)
 -   [openadds](https://github.com/sckott/openadds) is an R client for [OpenAddresses](http://openaddresses.io/) a free and open global address collection. [Source on GitHub](https://github.com/sckott/openadds)
 
-###Google Analytics###
+##Google Analytics##
 
 -   [ganalytics](https://github.com/jdeboer/ganalytics) (not on CRAN): Interface to [Google Analytics APIs](https://developers.google.com/analytics/). [Source on GitHub](https://github.com/jdeboer/ganalytics)
 -   <pkg>GAR</pkg>: Interface to [Google Analytics APIs](https://developers.google.com/analytics/). [Source on GitHub](https://github.com/andrewgeisler/GAR)
 -   <pkg>RGA</pkg>: Provides functions for accessing and retrieving data from the [Google Analytics APIs](https://developers.google.com/analytics/). Supports OAuth 2.0 authorization. Also, the RGA package provides a shiny app to explore data. There is another R package for the same service (RGoogleAnalytics); see above entry.
 -   <pkg>RGoogleAnalytics</pkg>: Provides functions for accessing and retrieving data from the Google Analytics API. [Source on GitHub](https://github.com/Tatvic/RGoogleAnalytics/issues). There is another R package for the same service (RGA); see next entry.
 
-###Google Web Services###
+##Google Web Services##
 
 -   <pkg>bigrquery</pkg>: An interface to Google's bigquery from R. [Source on GitHub](https://github.com/hadley/bigrquery) (K)
 -   [ganalytics](https://github.com/jdeboer/ganalytics) (not on CRAN): Interface to [Google Analytics APIs](https://developers.google.com/analytics/). [Source on GitHub](https://github.com/jdeboer/ganalytics) (K)
@@ -217,7 +190,7 @@ Data archiving involves the production and dissemination of open data that is pe
 -   <pkg>translate</pkg>: Bindings for the Google Translate API v2
 -   <pkg>translateR</pkg> provides bindings for both Google and Microsoft translation APIs.
 
-###Government###
+##Government##
 
 There are a very large number of packages providing access to government data. Here is a list of these packages, arranged by country and/or other jurisdiction.
 
@@ -268,7 +241,7 @@ There are a very large number of packages providing access to government data. H
     -   World Bank: <pkg>wbstats</pkg> can extract data from the [World Bank Data API](http://data.worldbank.org/developers/api-overview) and the [World Bank Data Catalog API](http://data.worldbank.org/developers/data-catalog-api). <pkg>WDI</pkg> can search, extract and format data from the World Bank's World Development Indicators.
 
 
-###Literature, Metadata, Text, and Altmetrics###
+##Literature, Metadata, Text, and Altmetrics##
 
 -   <pkg>alm</pkg>: R wrapper to the almetrics API platform developed by PLoS.
 -   <pkg>aRxiv</pkg> ([GitHub](https://github.com/ropensci/aRxiv)): An R client for the arXiv API, a repository of electronic preprints for computer science, mathematics, physics, quantitative biology, quantitative finance, and statistics.
@@ -293,7 +266,7 @@ There are a very large number of packages providing access to government data. H
 -   <pkg>tm.plugin.webmining</pkg>: Extensible text retrieval framework for news feeds in XML (RSS, ATOM) and JSON formats. Currently, the following feeds are implemented: Google Blog Search, Google Finance, Google News, NYTimes Article Search, Reuters News Feed, Yahoo Finance and Yahoo Inplay.
 *   <pkg>biorxivr</pkg>: interface with bioRxiv preprint server
 
-###Maps###
+##Maps##
 
 -   <pkg>FedData</pkg> can download geospatial data from a number of U.S. and international data sources.
 -   <pkg>ggmap</pkg>: Allows for the easy visualization of spatial data and models on top of Google Maps, OpenStreetMaps, Stamen Maps, or CloudMade Maps using ggplot2.
@@ -311,7 +284,7 @@ There are a very large number of packages providing access to government data. H
 -   <pkg>USAboundaries</pkg> spatial objects with the boundaries of states or counties in the United States of America from 1629 to 2000 (from the Atlas of Historical County Boundaries).
 
 
-###NCBI###
+##NCBI##
 
 -   <pkg>hoardeR</pkg>: Information retrieval from NCBI databases, with main focus on Blast.
 -   [NCBI2R](http://cran.rstudio.com/src/contrib/Archive/NCBI2R/): Annotates lists of SNPs and/or genes, with current information from NCBI. The CRAN version is archived.
@@ -319,13 +292,13 @@ There are a very large number of packages providing access to government data. H
 -   <pkg>reutils</pkg> ([GitHub](https://github.com/gschofl/reutils)): Interface with NCBI databases such as PubMed, Genbank, or GEO via the Entrez Programming Utilities (EUtils).
 -   <pkg>RISmed</pkg>: Download content from NCBI databases. Intended for analyses of NCBI database content, not reference management. See rpubmed for more literature oriented stuff from NCBI.
 
-###News###
+##News##
 
 -   <pkg>GuardianR</pkg>: Provides an interface to the Open Platform's Content API of the Guardian Media Group. It retrieves content from news outlets The Observer, The Guardian, and guardian.co.uk from 1999 to current day. <pkg>rdian</pkg> ([GitHub](https://github.com/ironholds/rdian)) is another Guardian API client.
 -   [rtimes](https://github.com/ropengov/rtimes) (not on CRAN): R client for the New York Times APIs, including the Congress, Article Search, Campaign Finance, and Geographic APIs.
 -   <em>ZEIT</em>: <pkg>diezeit</pkg> waps the ZEIT online content API (K).
 
-###Other###
+##Other##
 
 -   <pkg>datamart</pkg>: Provides an S4 infrastructure for unified handling of internal datasets and web based data sources. Examples include dbpedia, eurostat and sourceforge.
 -   <pkg>genderizeR</pkg>: Uses the genderize.io API to predict gender from first names extracted from a text vector. [Source on GitHub](https://github.com/kalimu/genderizeR)
@@ -341,7 +314,7 @@ There are a very large number of packages providing access to government data. H
 -   <pkg>TMDb</pkg> can retrieve data from [The Movie Database](https://www.themoviedb.org).
 -   <pkg>zendeskR</pkg>: This package provides an R wrapper for the Zendesk API. (\$)
 
-###Public Health###
+##Public Health##
 
 -   [cdcfluview](https://github.com/hrbrmstr/cdcfluview): (not on CRAN) R client for CDC FluView data (WHO and ILINet).
 -   <pkg>nhanesA</pkg> Utility to retrieve data from the National Health and Nutrition Examination Survey (NHANES).
@@ -352,7 +325,7 @@ There are a very large number of packages providing access to government data. H
 -   [vaers](https://gitlab.com/iembry/vaers) (not on CRAN) provides U.S. vaccine adverse event data from the [VAERS](https://vaers.hhs.gov/index) vaccine surveillance program. <pkg>vaersvax</pkg> provides a subset a subset of these data for three months of 2016. <pkg>vaersNDvax</pkg> provides non-domestic data for the same period.
 -   WHO: <pkg>WHO</pkg> ([GitHub](https://www.github.com/expersso/WHO)) provides an interface to the [World Health Organization](http://www.who.int/) API. <pkg>rgho</pkg> ([GitHub](https://github.com/pierucci/rgho)) connects to the WHO Global Health Observatory data.
 
-###Social media###
+##Social media##
 
 -   <em>Facebook</em>: <pkg>Rfacebook</pkg> provides an interface to the Facebook API. (K)
 -   <em>Google+</em>: <pkg>plusser</pkg> has been designed to to facilitate the retrieval of Google+ profiles, pages and posts. It also provides search facilities. Currently a Google+ API key is required for accessing Google+ data. [tuber](https://github.com/soodoku/tuber) provides bindings for YouTube API. Only on Github for now. (K)
@@ -363,7 +336,7 @@ There are a very large number of packages providing access to government data. H
 -   <pkg>SocialMediaLab</pkg> provides a convenient wrapper around many other social media clients and enables the construction of network structures from those data.
 -   <pkg>SocialMediaMineR</pkg> is an analytic tool that returns information about the popularity of a URL on social media sites.
 
-###Social science###
+##Social science##
 
 -   [asdfree: analyze survey data for free](http://www.asdfree.com/) (not a package) provides lots of code examples for analyzing survey data in R. Also on [github](https://github.com/ajdamico/usgsd).
 -   <pkg>brewdata</pkg> Retrieves and parses graduate admissions survey data from the [Grad Cafe website](http://thegradcafe.com).
@@ -377,7 +350,7 @@ There are a very large number of packages providing access to government data. H
 -   <pkg>wordbankr</pkg> ([GitHub](https://github.com/langcog/wordbankr)) connects to [Wordbank](http://wordbank.stanford.edu/), a database of childrens' developmental vocabulary.
 -   The <ohat>Zillow</ohat> (not on CRAN) package provides an R interface to the [Zillow](http://www.zillow.com/) Web Service API. It allows one to get the Zillow estimate for the price of a particular property specified by street address and ZIP code (or city and state), to find information (e.g. size of property and lot, number of bedrooms and bathrooms, year built.) about a given property, and to get comparable properties.
 
-###Sports###
+##Sports##
 
 -   [abettor](https://github.com/phillc73/abettor) (not on CRAN): Online betting exchange, Betfair, API wrapper in R. (K)
 -   [ballr](https://github.com/rtelmore/ballr) (not on CRAN) is a client for [Basketball-Reference.com](http://www.basketball-reference.com/).
@@ -393,7 +366,7 @@ There are a very large number of packages providing access to government data. H
 -   <pkg>retrosheet</pkg> ([Github](https://github.com/rmscriven/retrosheet)) retrieves single-season baseball statistics from <http://www.retrosheet.org>.
 -   <pkg>yorkr</pkg> provides access to cricket data from [Cricsheet](http://cricsheet.org).
 
-###Web Analytics###
+##Web Analytics##
 
 -   [GTrendsR](https://github.com/dvanclev/GTrendsR) (not on CRAN): R functions to perform and display Google Trends queries. Another Github package ([rGtrends](https://github.com/emhart/rGtrends)) is now deprecated, but supported a previous version of Google Trends and may still be useful for developers.
 -   rgauges ([Archived on CRAN](https://cran.r-project.org/src/contrib/Archive/rgauges)) This package provides functions to interact with the Gaug.es API. Gaug.es is a web analytics service, like Google analytics. You have to have a Gaug.es account to use this package. (\$) (K)
@@ -402,7 +375,7 @@ There are a very large number of packages providing access to government data. H
 -   <ohat>RGoogleTrends</ohat> (not on CRAN) provides programmatic access to Google Trends data. This is information about the popularity of a particular query.
 -   <pkg>RSiteCatalyst</pkg>: Functions for accessing the Adobe Analytics (Omniture SiteCatalyst) Reporting API.
 
-### Wikipedia/Wikimedia ###
+## Wikipedia/Wikimedia ##
 
 -   [wikipediatrend](https://github.com/petermeissner/wikipediatrend) (removed from CRAN): Provides access to Wikipedia page access statistics.
 -   <pkg>WikipediR</pkg>: WikipediR is a wrapper for the MediaWiki API, aimed particularly at the Wikimedia 'production' wikis, such as Wikipedia. [Source on GitHub](https://github.com/Ironholds/WikipediR)


### PR DESCRIPTION
Work on #114 to focus this task view, as Achim suggested,
on web-based open data resources. Remove the Data Sharing and
Archiving section and up date the lede text to describe narrower
focus.
